### PR TITLE
feat: Implement order service API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,18 @@
 			<artifactId>mysql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>rest-assured</artifactId>
+			<version>5.5.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+			<version>2.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/michael/order_service/controller/OrderController.java
+++ b/src/main/java/com/michael/order_service/controller/OrderController.java
@@ -1,0 +1,25 @@
+package com.michael.order_service.controller;
+
+import com.michael.order_service.dto.OrderRequest;
+import com.michael.order_service.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/order")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<String> placeOrder(@RequestBody OrderRequest orderRequest){
+        orderService.placeOrder(orderRequest);
+        return new ResponseEntity<>("order placed successfully", HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/michael/order_service/dto/OrderRequest.java
+++ b/src/main/java/com/michael/order_service/dto/OrderRequest.java
@@ -1,0 +1,12 @@
+package com.michael.order_service.dto;
+
+import java.math.BigDecimal;
+
+public record OrderRequest(
+        Long id,
+        String orderNumber,
+        String skuCode,
+        BigDecimal price,
+        Integer quantity
+) {
+}

--- a/src/main/java/com/michael/order_service/model/Order.java
+++ b/src/main/java/com/michael/order_service/model/Order.java
@@ -1,0 +1,26 @@
+package com.michael.order_service.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "t_orders")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String orderNumber;
+    private String skuCode;
+    private BigDecimal price;
+    private Integer quantity;
+}

--- a/src/main/java/com/michael/order_service/repository/OrderRepository.java
+++ b/src/main/java/com/michael/order_service/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package com.michael.order_service.repository;
+
+import com.michael.order_service.model.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/michael/order_service/service/OrderService.java
+++ b/src/main/java/com/michael/order_service/service/OrderService.java
@@ -1,0 +1,28 @@
+package com.michael.order_service.service;
+
+import com.michael.order_service.dto.OrderRequest;
+import com.michael.order_service.model.Order;
+import com.michael.order_service.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    public void placeOrder(OrderRequest orderRequest){
+        Order order = new Order();
+        order.setId(orderRequest.id());
+        order.setOrderNumber(orderRequest.orderNumber());
+        order.setSkuCode(orderRequest.skuCode());
+        order.setPrice(orderRequest.price());
+        order.setQuantity(orderRequest.quantity());
+
+        orderRepository.save(order);
+        log.info("order placed successfully");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=order-service
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/order_service
 spring.datasource.username=root
 spring.datasource.password=mysql

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `t_orders`
+(
+    `id` bigint(20) NOT NULL AUTO_INCREMENT,
+    `order_number` varchar(255) DEFAULT NULL,
+    `sku_code` varchar(255),
+    `price` decimal(19,2),
+    `quantity` int(11),
+    PRIMARY KEY (`id`)
+);

--- a/src/test/java/com/michael/order_service/OrderServiceApplicationTests.java
+++ b/src/test/java/com/michael/order_service/OrderServiceApplicationTests.java
@@ -1,15 +1,55 @@
 package com.michael.order_service;
 
+import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.MySQLContainer;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-@Import(TestcontainersConfiguration.class)
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class OrderServiceApplicationTests {
 
+	@ServiceConnection
+	static MySQLContainer mySQLContainer = new MySQLContainer<>("mysql:8.3.0");
+	@LocalServerPort
+	private Integer port;
+
+	@BeforeEach
+	void setup(){
+		RestAssured.baseURI = "http://localhost";
+		RestAssured.port = port;
+	}
+
+	static {
+		mySQLContainer.start();
+	}
+
 	@Test
-	void contextLoads() {
+	void shouldCreateOrder() {
+		String requestBody = """
+				{
+				     "skuCode":"Iphone_15",
+				     "price": 1000,
+				     "quantity": 1
+				}
+				""";
+
+		var responseBodyString = RestAssured.given()
+				.contentType("application/json")
+				.body(requestBody)
+				.when()
+				.post("/api/order")
+				.then()
+				.log().all()
+				.statusCode(200)
+				.extract()
+				.body().asString();
+
+		assertThat(responseBodyString, Matchers.is("order placed successfully"));
 	}
 
 }


### PR DESCRIPTION
This commit introduces the initial API for the order service, including one new endpoint for creating an order. It also sets up the foundational model and repository layers.

Key changes:
- Created the Order model to represent the order entity.
- Implemented the OrderRepository for data access.
- Created the /order endpoint to create a new order.
- Added OrderRequest record for data transfer.
- Used FlyWay for database migration.
- Implemented integration tests for new endpoint using Testcontainers and Rest Assured.