### PR TITLE
feat: sync communication using open feign

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<spring-cloud.version>2025.0.0</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -37,6 +38,10 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>
@@ -90,7 +95,23 @@
 			<version>2.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-contract-stub-runner</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/michael/order_service/OrderServiceApplication.java
+++ b/src/main/java/com/michael/order_service/OrderServiceApplication.java
@@ -2,8 +2,10 @@ package com.michael.order_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class OrderServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/michael/order_service/client/InventoryClient.java
+++ b/src/main/java/com/michael/order_service/client/InventoryClient.java
@@ -1,0 +1,13 @@
+package com.michael.order_service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(value = "inventory", url = "${inventory-url}")
+public interface InventoryClient {
+
+    @RequestMapping(method = RequestMethod.GET, value = "/api/inventory")
+    boolean isInStock(@RequestParam String skuCode, @RequestParam Integer quantity);
+}

--- a/src/main/java/com/michael/order_service/controller/OrderController.java
+++ b/src/main/java/com/michael/order_service/controller/OrderController.java
@@ -19,7 +19,6 @@ public class OrderController {
 
     @PostMapping
     public ResponseEntity<String> placeOrder(@RequestBody OrderRequest orderRequest){
-        orderService.placeOrder(orderRequest);
-        return new ResponseEntity<>("order placed successfully", HttpStatus.OK);
+        return new ResponseEntity<>(orderService.placeOrder(orderRequest), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/michael/order_service/service/OrderService.java
+++ b/src/main/java/com/michael/order_service/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.michael.order_service.service;
 
+import com.michael.order_service.client.InventoryClient;
 import com.michael.order_service.dto.OrderRequest;
 import com.michael.order_service.model.Order;
 import com.michael.order_service.repository.OrderRepository;
@@ -13,16 +14,25 @@ import org.springframework.stereotype.Service;
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final InventoryClient inventoryClient;
 
-    public void placeOrder(OrderRequest orderRequest){
-        Order order = new Order();
-        order.setId(orderRequest.id());
-        order.setOrderNumber(orderRequest.orderNumber());
-        order.setSkuCode(orderRequest.skuCode());
-        order.setPrice(orderRequest.price());
-        order.setQuantity(orderRequest.quantity());
+    public String placeOrder(OrderRequest orderRequest){
+        var isProductInStock = inventoryClient.isInStock(orderRequest.skuCode(), orderRequest.quantity());
 
-        orderRepository.save(order);
-        log.info("order placed successfully");
+        if(isProductInStock) {
+            Order order = new Order();
+            order.setId(orderRequest.id());
+            order.setOrderNumber(orderRequest.orderNumber());
+            order.setSkuCode(orderRequest.skuCode());
+            order.setPrice(orderRequest.price());
+            order.setQuantity(orderRequest.quantity());
+
+            orderRepository.save(order);
+            log.info("order placed successfully");
+            return "order placed successfully";
+        }else {
+            return "Product with SkuCode: "+ orderRequest.skuCode()+" is not in stock";
+        }
+
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,4 @@ spring.datasource.username=root
 spring.datasource.password=mysql
 spring.jpa.hibernate.ddl-auto=none
 server.port=8081
+inventory-url=http://localhost:8082

--- a/src/test/java/com/michael/order_service/stubs/InventoryClientStub.java
+++ b/src/test/java/com/michael/order_service/stubs/InventoryClientStub.java
@@ -1,0 +1,22 @@
+package com.michael.order_service.stubs;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+public class InventoryClientStub {
+
+    public static void stubInventoryCallInStock(String skuCode, Integer quantity){
+        stubFor(get(urlEqualTo("/api/inventory?skuCode="+skuCode+"&quantity="+quantity))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type","application/json")
+                        .withBody("true")));
+    }
+
+    public static void stubInventoryCallOutOfStock(String skuCode, Integer quantity){
+        stubFor(get(urlEqualTo("/api/inventory?skuCode="+skuCode+"&quantity="+quantity))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type","application/json")
+                        .withBody("false")));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+inventory-url=http://localhost:${wiremock.server.port}


### PR DESCRIPTION
This commit introduces the sync communication between order service and inventory service using open feign.

Key changes:
- Created the feign client to call the isInStock endpoint on the inventory service.
- Chore: updated the integration tests to use feign client stub and wiremock to mock the http call to the inventory service and check for product ability.
- Updated the response from the /order endpoint service to return String based on the workflow.